### PR TITLE
Fix NullPointerException in MatchListener

### DIFF
--- a/src/main/java/dev/nandi0813/practice/Manager/Match/MatchListener.java
+++ b/src/main/java/dev/nandi0813/practice/Manager/Match/MatchListener.java
@@ -317,16 +317,18 @@ public class MatchListener implements Listener
     }
 
     @EventHandler
-    public void onRegen(EntityRegainHealthEvent e)
-    {
-        Player player = (Player) e.getEntity();
-        Profile profile = Practice.getProfileManager().getProfiles().get(player);
-        Match match = Practice.getMatchManager().getLiveMatchByPlayer(player);
+    public void onRegen(EntityRegainHealthEvent e) {
+        if (e.getEntity() instanceof Player) {
+            Player player = (Player) e.getEntity();
+            Profile profile = Practice.getProfileManager().getProfiles().get(player);
+            Match match = Practice.getMatchManager().getLiveMatchByPlayer(player);
 
-        if (profile.getStatus().equals(ProfileStatus.MATCH))
-        {
-            if (!match.getLadder().isRegen() && e.getRegainReason() == EntityRegainHealthEvent.RegainReason.SATIATED)
-                e.setCancelled(true);
+            if (profile != null && match != null && profile.getStatus().equals(ProfileStatus.MATCH)) {
+                {
+                    if (!match.getLadder().isRegen() && e.getRegainReason() == EntityRegainHealthEvent.RegainReason.SATIATED)
+                        e.setCancelled(true);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Caused by: java.lang.ClassCastException: class org.bukkit.craftbukkit.v1_8_R3.entity.CraftHorse cannot be cast to class org.bukkit.entity.Player (org.bukkit.craftbukkit.v1_8_R3.entity.CraftHorse and org.bukkit.entity.Player are in unnamed module of loader 'app')