### PR TITLE
Caused by: java.util.ConcurrentModificationException

### DIFF
--- a/src/main/java/dev/nandi0813/practice/Manager/Gui/GUIs/RankedGui.java
+++ b/src/main/java/dev/nandi0813/practice/Manager/Gui/GUIs/RankedGui.java
@@ -45,7 +45,9 @@ public class RankedGui extends GUI
         gui.get(1).clear();
         ladderSlots.clear();
 
-        for (Ladder ladder : Practice.getLadderManager().getLadders())
+        List<Ladder> ladders = new ArrayList<>(Practice.getLadderManager().getLadders());
+
+        for (Ladder ladder : ladders)
         {
             if (ladder.isRanked() && ladder.isEnabled() && ladder.getIcon() != null)
             {


### PR DESCRIPTION
[15:14:31 WARN]: Exception in thread "Craft Scheduler Thread - 0" [15:14:31 WARN]: org.apache.commons.lang.UnhandledException: Plugin ZonePracticeLite v3.04-SNAPSHOT generated an exception while executing task 19 at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) at org.github.paperspigot.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:23) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) at java.base/java.lang.Thread.run(Thread.java:1583) Caused by: java.util.ConcurrentModificationException at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1095) at java.base/java.util.ArrayList$Itr.next(ArrayList.java:1049) at dev.nandi0813.practice.Manager.Gui.GUIs.RankedGui.update(RankedGui.java:48) at dev.nandi0813.practice.Manager.Gui.GUIs.RankedGui.build(RankedGui.java:39) at dev.nandi0813.practice.Manager.Gui.GUIs.RankedGui.<init>(RankedGui.java:33) at dev.nandi0813.practice.Manager.Gui.GUIManager.buildGUIs(GUIManager.java:46) at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:59) at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:53) ... 4 more