### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/dev/nandi0813/practice/Manager/Gui/GUIs/Match/LadderSelector.java
+++ b/src/main/java/dev/nandi0813/practice/Manager/Gui/GUIs/Match/LadderSelector.java
@@ -34,7 +34,7 @@ public class LadderSelector extends GUI
         super(GUIType.LADDER_SELECTOR);
         this.matchType = matchType;
 
-        this.gui.put(1, InventoryUtil.createInventory(LanguageManager.getString("gui.ladder-selector.title").replaceAll("%matchTypeName%", matchType.getName()), 1));
+        this.gui.put(1, InventoryUtil.createInventory(LanguageManager.getString("gui.ladder-selector.title").replaceAll("%matchTypeName%", matchType.getName()), (int) Math.ceil(Practice.getLadderManager().getUnrankedLadders().size() / 9.)));
 
         build();
     }

--- a/src/main/java/dev/nandi0813/practice/Manager/Gui/GUIs/RankedGui.java
+++ b/src/main/java/dev/nandi0813/practice/Manager/Gui/GUIs/RankedGui.java
@@ -28,7 +28,8 @@ public class RankedGui extends GUI
     public RankedGui()
     {
         super(GUIType.QUEUE_RANKED);
-        this.gui.put(1, InventoryUtil.createInventory(LanguageManager.getString("gui.ranked.title"), 1));
+        this.gui.put(1, InventoryUtil.createInventory(LanguageManager.getString("gui.ranked.title"),
+                (int) Math.ceil(Practice.getLadderManager().getRankedLadders().size() / 9.)));
 
         build();
     }
@@ -45,9 +46,8 @@ public class RankedGui extends GUI
         gui.get(1).clear();
         ladderSlots.clear();
 
-        for (Ladder ladder : Practice.getLadderManager().getLadders())
+        for (Ladder ladder : Practice.getLadderManager().getRankedLadders())
         {
-            if (ladder.isRanked() && ladder.isEnabled() && ladder.getIcon() != null)
             {
                 ItemStack icon = ladder.getIcon().clone();
                 ItemMeta iconMeta = icon.getItemMeta();

--- a/src/main/java/dev/nandi0813/practice/Manager/Gui/GUIs/UnrankedGui.java
+++ b/src/main/java/dev/nandi0813/practice/Manager/Gui/GUIs/UnrankedGui.java
@@ -28,7 +28,8 @@ public class UnrankedGui extends GUI
     public UnrankedGui()
     {
         super(GUIType.QUEUE_UNRANKED);
-        this.gui.put(1, InventoryUtil.createInventory(LanguageManager.getString("gui.unranked.title"), 1));
+        this.gui.put(1, InventoryUtil.createInventory(LanguageManager.getString("gui.unranked.title"),
+                (int) Math.ceil(Practice.getLadderManager().getUnrankedLadders().size() / 9.)));
 
         build();
     }
@@ -45,9 +46,8 @@ public class UnrankedGui extends GUI
         gui.get(1).clear();
         ladderSlots.clear();
 
-        for (Ladder ladder : Practice.getLadderManager().getLadders())
+        for (Ladder ladder : Practice.getLadderManager().getUnrankedLadders())
         {
-            if (ladder.isEnabled() && ladder.getIcon() != null)
             {
                 ItemStack icon = ladder.getIcon().clone();
                 ItemMeta iconMeta = icon.getItemMeta();

--- a/src/main/java/dev/nandi0813/practice/Manager/Ladder/LadderManager.java
+++ b/src/main/java/dev/nandi0813/practice/Manager/Ladder/LadderManager.java
@@ -4,14 +4,18 @@ import dev.nandi0813.practice.Manager.File.LadderFile;
 import dev.nandi0813.practice.Practice;
 import lombok.Getter;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
 public class LadderManager
 {
 
-    @Getter private final List<Ladder> ladders = new ArrayList<>();
+    private final List<Ladder> ladders = new ArrayList<>();
+    private final List<Ladder> unrankedLadders = new ArrayList<>();
+    private final List<Ladder> rankedLadders = new ArrayList<>();
 
     /**
      * Return the ladder with the given name, or null if no ladder with that name exists.
@@ -38,12 +42,27 @@ public class LadderManager
     /**
      * Loads all the ladders into the ladders list
      */
-    public void loadLadders()
-    {
+    public void loadLadders() {
         Bukkit.getScheduler().runTaskAsynchronously(Practice.getInstance(), () ->
         {
-            for (int id = 1; id < 10; id++)
-                ladders.add(new Ladder(id));
+            ladders.clear();
+            rankedLadders.clear();
+            unrankedLadders.clear();
+
+            FileConfiguration config = LadderFile.getConfig();
+
+            for (String ladderName : config.getConfigurationSection("ladders").getKeys(false)) {
+                Ladder ladder = new Ladder(Integer.parseInt(ladderName.replace("ladder", "")));
+                ladders.add(ladder);
+
+                if (ladder.isEnabled() && ladder.getIcon() != null) {
+                    unrankedLadders.add(ladder);
+
+                    if (ladder.isRegen()) {
+                        rankedLadders.add(ladder);
+                    }
+                }
+            }
         });
     }
 

--- a/src/main/java/dev/nandi0813/practice/Manager/Queue/Queue.java
+++ b/src/main/java/dev/nandi0813/practice/Manager/Queue/Queue.java
@@ -68,7 +68,7 @@ public class Queue
                     @Override
                     public void run()
                     {
-                        int elo = profile.getElo().get(ladder);
+                        int elo = profile.getElo().getOrDefault(ladder, ConfigManager.getConfig().getInt("ranked.default-elo"));
                         if (queueManager.getQueue(getPlayer()) == null || elo - getRange() <= 0)
                         {
                             queueRunnable.cancel();


### PR DESCRIPTION
[02:11:05 WARN]: Exception in thread "Craft Scheduler Thread - 9" 
[02:11:05 WARN]: org.apache.commons.lang.UnhandledException: Plugin ZonePracticeLite v3.1-SNAPSHOT generated an exception while executing task 285
	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
	at org.github.paperspigot.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:23)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "java.util.Map.get(Object)" is null
	at dev.nandi0813.practice.Manager.Queue.Queue$1.run(Queue.java:71)
	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:59)
	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:53)
	... 4 more 